### PR TITLE
Change behavior on estop

### DIFF
--- a/include/motion_tracer/lower_controller.h
+++ b/include/motion_tracer/lower_controller.h
@@ -33,11 +33,13 @@ public:
   void jointStateCallback(const sensor_msgs::JointState& _joint_data);
   void sendJointAngles();
   void getJoy(const sensor_msgs::JoyPtr& _ps3);
+  void diagnosticsCallback(const diagnostic_msgs::DiagnosticArrayPtr& _msg);
 
 private:
   ros::NodeHandle nh_;
   ros::Subscriber joint_state_sub_;
   ros::Subscriber joy_sub_;
+  ros::Subscriber diag_sub_;
 
   TrajectoryClient* lifter_client_;
 
@@ -59,7 +61,7 @@ private:
   const float knee_lower_limt = -1.57;
 
   float lifter_ratio_;
-  bool init;
+  bool init,on_protective_stop;
 
   //led control
   ros::ServiceClient led_client_;

--- a/launch/robot_bringup.launch
+++ b/launch/robot_bringup.launch
@@ -27,6 +27,7 @@
 
   <!-- other -->
 <!--
+  <include file="$(find motion_tracer)/launch/rs_camera.launch" />
   <node name="scan_throttler" type="throttle" pkg="topic_tools" args="messages /scan 2 /scan_throttle" />
   <node pkg="uvc_camera" name="uvc_camera_node" type="uvc_camera_node" />
 -->

--- a/launch/rs_camera.launch
+++ b/launch/rs_camera.launch
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="serial_no_camera1" default="950122070906"/> 
+  <arg name="camera1"           default="chest_camera"/>	
+  <arg name="tf_prefix_camera1" default="$(arg camera1)"/>
+
+<!--
+  <arg name="serial_no_camera2" default="948122071715"/> 
+  <arg name="camera2"           default="front_camera"/>		
+  <arg name="tf_prefix_camera2" default="$(arg camera2)"/>
+
+  <arg name="serial_no_camera3" default="948122071715"/> 
+  <arg name="camera3"           default="rear_camera"/>		
+  <arg name="tf_prefix_camera3" default="$(arg camera3)"/>
+-->
+  <group ns="$(arg camera1)">
+    <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+      <arg name="serial_no"     value="$(arg serial_no_camera1)"/>
+      <arg name="tf_prefix"     value="$(arg tf_prefix_camera1)"/>
+      <arg name="initial_reset" value="true"/>
+      <!-- <arg name="filters"       value="pointcloud"/> -->
+    </include>
+  </group>
+<!--
+  <group ns="$(arg camera2)">
+    <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+      <arg name="serial_no"     value="$(arg serial_no_camera2)"/>
+      <arg name="tf_prefix"     value="$(arg tf_prefix_camera2)"/>
+      <arg name="initial_reset" value="true"/>
+    </include>
+  </group>
+
+  <group ns="$(arg camera3)">
+    <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+      <arg name="serial_no"     value="$(arg serial_no_camera3)"/>
+      <arg name="tf_prefix"     value="$(arg tf_prefix_camera3)"/>
+      <arg name="initial_reset" value="true"/>
+    </include>
+  </group>
+
+-->
+</launch>

--- a/src/lower_controller.cpp
+++ b/src/lower_controller.cpp
@@ -1,7 +1,7 @@
 #include "motion_tracer/lower_controller.h"
 
 LowerController::LowerController(const ros::NodeHandle _nh) :
-  nh_(_nh),lifter_ratio_(0.01),init(true)
+  nh_(_nh),lifter_ratio_(0.01),init(true),on_protective_stop(false)
 {
 
   controller_rate_ = 50;
@@ -10,6 +10,7 @@ LowerController::LowerController(const ros::NodeHandle _nh) :
 
   joint_state_sub_ = nh_.subscribe("/joint_states",2, &LowerController::jointStateCallback,this);
   joy_sub_ = nh_.subscribe("/joy",2, &LowerController::getJoy,this);
+  diag_sub_ = nh_.subscribe("/diagnostics",1, &LowerController::diagnosticsCallback,this);
 
   init_follow_joint_trajectory();
 
@@ -65,6 +66,32 @@ void LowerController::getJoy(const sensor_msgs::JoyPtr& _ps3)
 
     sendJointAngles();
   }
+}
+
+void LowerController::diagnosticsCallback(const diagnostic_msgs::DiagnosticArrayPtr& _msg)
+{
+  std::string hardware_id = _msg->status[0].hardware_id;
+  std::map<std::string,std::string> status;
+
+  if(hardware_id.find("SEED-Noid-Mover") != std::string::npos){
+    for (int i=0; i < _msg->status[0].values.size(); ++i){
+      status[_msg->status[0].values[i].key] = _msg->status[0].values[i].value;
+    }
+  }
+
+  // send goal 0 when E-STOP pressed
+  if(status["Emergency Stopped"] == "True"){
+    joint_angles_["ankle"] = 0;
+    joint_angles_["knee"] = 0;
+    sendJointAngles();
+  }
+  else if(status["Protective Stopped"] == "True"){
+    on_protective_stop = true;
+  }
+  else if(status["Protective Stopped"] == "False"){
+    on_protective_stop = false;
+  }
+
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
非常停止ボタンを押してもfollow-joint-trajectory-controllerの軌道が残っていて、
復帰後に非常停止を押す前の位置から軌道生成をスタートしてしまう。

* 非常停止押し下げ後に、goalを0にすることで対応
* 保護停止時にジョイスティックの値を加算しないように変更

Realsenseのカメラを読み込むlaunchを追加